### PR TITLE
Fix bindED trying to load .binds file that doesn't exist.

### DIFF
--- a/bindED.cs
+++ b/bindED.cs
@@ -389,6 +389,11 @@ namespace bindEDplugin
             }
 
             IEnumerable<string> presets = File.ReadAllLines(startFile).Distinct();
+            
+            // Remove binds that don't exist
+            FileInfo[] bindFiles = new DirectoryInfo(BindingsDir).GetFiles("*.binds");
+            presets = presets.Where(p => bindFiles.Any(b => b.Name.StartsWith(p)));
+
             if (presets.Count() > 1)
             {
                 LogError($"You have selected multiple control presets ('{string.Join("', '", presets)}'). "


### PR DESCRIPTION
My StartPreset.4.start file contained the following lines:

```
KeyboardMouseOnly
Custom
Custom
KeyboardMouseOnly
```

This caused it to try to load "KeyboardMouseOnly" which does not exist.

This fixes the issue at least on my machine.